### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,4 @@ ENV PATH="/app/.venv/bin:$PATH"
 VOLUME /data
 ENV HF_HUB_CACHE="/data"
 ENTRYPOINT ["python", "-m", "wyoming_onnx_asr"]
-CMD [ "--uri", "tcp://localhost:10300", "--model_en", "nemo-parakeet-tdt-0.6b-v2" ]
+CMD [ "--uri", "tcp://localhost:10300", "--model-en", "nemo-parakeet-tdt-0.6b-v2" ]

--- a/gpu-tensorrt.Dockerfile
+++ b/gpu-tensorrt.Dockerfile
@@ -51,4 +51,4 @@ ENV ORT_TENSORRT_ENGINE_CACHE_ENABLE=1
 ENV ORT_TENSORRT_CACHE_PATH=/cache/tensorrt
 
 ENTRYPOINT ["python", "-m", "wyoming_onnx_asr", "--device", "gpu-trt"]
-CMD [ "--uri", "tcp://localhost:10300", "--model_en", "nemo-parakeet-tdt-0.6b-v2" ]
+CMD [ "--uri", "tcp://localhost:10300", "--model-en", "nemo-parakeet-tdt-0.6b-v2" ]

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -44,4 +44,4 @@ ENV PATH="/app/.venv/bin:$PATH"
 VOLUME /data
 ENV HF_HUB_CACHE="/data"
 ENTRYPOINT ["python", "-m", "wyoming_onnx_asr", "--device", "gpu"]
-CMD [ "--uri", "tcp://localhost:10300", "--model_en", "nemo-parakeet-tdt-0.6b-v2" ]
+CMD [ "--uri", "tcp://localhost:10300", "--model-en", "nemo-parakeet-tdt-0.6b-v2" ]


### PR DESCRIPTION
This pull request fixes an issue for a command-line argument across multiple Dockerfiles by replacing `--model_en` with `--model-en`.

Changes to command-line arguments:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L47-R47): Updated the `CMD` instruction to use `--model-en` instead of `--model_en`.
* [`gpu-tensorrt.Dockerfile`](diffhunk://#diff-2b117686a554dc37257c4fa8f26c9a10ce8489c1eada3432244b3fc2e6b86f23L54-R54): Updated the `CMD` instruction to use `--model-en` instead of `--model_en`.
* [`gpu.Dockerfile`](diffhunk://#diff-9f95bd7531b4b23ca4bf777bbf9120bc1c330b24791b98724cf3007a65d07f64L47-R47): Updated the `CMD` instruction to use `--model-en` instead of `--model_en`.